### PR TITLE
Link buildpack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Run your own Kibana instance with one click.
 
 [![Deploy](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy)
 
-Documentation about the buildback https://github.com/Scalingo/kibana-buildpack
+Documentation about the buildback [https://github.com/Scalingo/kibana-buildpack](https://github.com/Scalingo/kibana-buildpack)

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 Run your own Kibana instance with one click.
 
 [![Deploy](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy)
+
+Documentation about the buildback https://github.com/Scalingo/kibana-buildpack


### PR DESCRIPTION
Link buildpack documentation into the readme, as it be the one linked to the one-click deploy process
![image](https://user-images.githubusercontent.com/62012562/129201764-25faf0c1-c8bb-4471-9c6f-20a5b90a58de.png)
